### PR TITLE
Add AFK-Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Make sure to have proper overflow protection in your farms!
 - Use `/autorelog config delay <delay>` to set the amount of time in seconds AutoRelog should wait before trying to reconnect.
 - Use `/autorelog config interval <interval>` to set the interval between reconnection attempts.
 - Use `/autorelog config maxAttempts <maxAttempts>` to set the maximal amount of reconnection attempts. Zero or negative numbers will result in unlimited attempts.
+- Use `/autorelog config mode <automatic/manual>` to toggle switch between AFK-Detection and manual mode.
+- Use `/autorelog config afkDelay <delay>` to set the amount of time in seconds the player has to be afk for automatic reconnection to work.
 - Disconnect by leaving the server manually or use `/autorelog cancel` to deactivate.
 
 Delay and interval can also be changed in the config file (autorelog.conf).

--- a/src/main/java/com/scubakay/autorelog/commands/AutoRelogCommand.java
+++ b/src/main/java/com/scubakay/autorelog/commands/AutoRelogCommand.java
@@ -6,6 +6,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.scubakay.autorelog.AutoRelogClient;
+import com.scubakay.autorelog.commands.suggestions.AfkDelaySuggestionsProvider;
 import com.scubakay.autorelog.commands.suggestions.DelaySuggestionProvider;
 import com.scubakay.autorelog.commands.suggestions.IntervalSuggestionProvider;
 import com.scubakay.autorelog.commands.suggestions.MaxAttemptsSuggestionProvider;
@@ -61,6 +62,30 @@ public class AutoRelogCommand {
                 .executes(AutoRelogCommand::cancel)
                 .build();
 
+        LiteralCommandNode<FabricClientCommandSource> modeNode = ClientCommandManager
+                .literal("mode")
+                .build();
+
+        LiteralCommandNode<FabricClientCommandSource> manualModeNode = ClientCommandManager
+                .literal("manual")
+                .executes(AutoRelogCommand::manualMode)
+                .build();
+
+        LiteralCommandNode<FabricClientCommandSource> automaticModeNode = ClientCommandManager
+                .literal("automatic")
+                .executes(AutoRelogCommand::afkDetectionMode)
+                .build();
+
+        LiteralCommandNode<FabricClientCommandSource> afkDelayNode = ClientCommandManager
+                .literal("afkDelay")
+                .build();
+
+        ArgumentCommandNode<FabricClientCommandSource, Integer> afkDelayArgumentNode = ClientCommandManager
+                .argument("afkDelay", IntegerArgumentType.integer())
+                .suggests(new AfkDelaySuggestionsProvider())
+                .executes(ctx -> afkDelay(ctx, IntegerArgumentType.getInteger(ctx, "afkDelay")))
+                .build();
+
         dispatcher.getRoot().addChild(autoRelogNode);
 
         // Add config node
@@ -77,6 +102,13 @@ public class AutoRelogCommand {
         // Add max attempts config node
         configNode.addChild(maxAttemptsNode);
         maxAttemptsNode.addChild(maxAttemptsArgumentNode);
+
+        configNode.addChild(modeNode);
+        modeNode.addChild(manualModeNode);
+        modeNode.addChild(automaticModeNode);
+
+        configNode.addChild(afkDelayNode);
+        afkDelayNode.addChild(afkDelayArgumentNode);
 
         autoRelogNode.addChild(cancelNode);
     }
@@ -128,6 +160,29 @@ public class AutoRelogCommand {
         }
         AutoRelogClient.CONFIG.setMaxAttempts(maxAttempts);
         context.getSource().getPlayer().sendMessage(Text.translatable("commands.autorelog_max_attempts_changed", maxAttempts), false);
+        return 1;
+    }
+
+    private static int afkDelay(CommandContext<FabricClientCommandSource> context, int afkDelay) {
+        if (afkDelay < 0) {
+            context.getSource().getPlayer().sendMessage(Text.translatable("commands.config_error_delay"), false);
+            return -1;
+        }
+        AutoRelogClient.CONFIG.setAfkDelay(afkDelay);
+        context.getSource().getPlayer().sendMessage(Text.translatable("commands.afkDetection.delayChanged", afkDelay), false);
+        return 1;
+    }
+
+    private static int manualMode(CommandContext<FabricClientCommandSource> context) {
+        if(AutoRelogClient.CONFIG.isAfkDetection()) Reconnect.getInstance().deactivate();
+        AutoRelogClient.CONFIG.setAfkDetection(false);
+        context.getSource().getPlayer().sendMessage(Text.translatable("commands.mode.manual"), false);
+        return 1;
+    }
+
+    private static int afkDetectionMode(CommandContext<FabricClientCommandSource> context) {
+        AutoRelogClient.CONFIG.setAfkDetection(true);
+        context.getSource().getPlayer().sendMessage(Text.translatable("commands.mode.afkDetection"), false);
         return 1;
     }
 }

--- a/src/main/java/com/scubakay/autorelog/commands/suggestions/AfkDelaySuggestionsProvider.java
+++ b/src/main/java/com/scubakay/autorelog/commands/suggestions/AfkDelaySuggestionsProvider.java
@@ -1,0 +1,19 @@
+package com.scubakay.autorelog.commands.suggestions;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.scubakay.autorelog.AutoRelogClient;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+
+import java.util.concurrent.CompletableFuture;
+
+public class AfkDelaySuggestionsProvider implements SuggestionProvider<FabricClientCommandSource> {
+    @Override
+    public CompletableFuture<Suggestions> getSuggestions(CommandContext<FabricClientCommandSource> context, SuggestionsBuilder builder) throws CommandSyntaxException {
+        builder.suggest(AutoRelogClient.CONFIG.getAfkDelay());
+        return builder.buildFuture();
+    }
+}

--- a/src/main/java/com/scubakay/autorelog/config/Config.java
+++ b/src/main/java/com/scubakay/autorelog/config/Config.java
@@ -13,16 +13,22 @@ public class Config {
     private final static int DEFAULT_INTERVAL = 30;
     private final static int DEFAULT_MAX_ATTEMPTS = 5;
 
+    private final static boolean DEFAULT_AFK_DETECTION = false;
+    private final static int DEFAULT_AFK_DELAY = 60;
+
     private int delay;
     private int interval;
     private int maxAttempts;
+
+    private boolean afkDetection;
+    private int afkDelay;
 
     public int getDelay() {
         return delay;
     }
 
-    public void setDelay(int interval) {
-        this.delay = interval;
+    public void setDelay(int delay) {
+        this.delay = delay;
         save();
     }
 
@@ -44,6 +50,24 @@ public class Config {
         save();
     }
 
+    public boolean isAfkDetection() {
+        return afkDetection;
+    }
+
+    public void setAfkDetection(boolean enabled) {
+        this.afkDetection = enabled;
+        save();
+    }
+
+    public int getAfkDelay() {
+        return afkDelay;
+    }
+
+    public void setAfkDelay(int delay) {
+        this.afkDelay = delay;
+        save();
+    }
+
     final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
             .path(Path.of("config/autorelog.conf"))
             .build();
@@ -61,11 +85,15 @@ public class Config {
                 delay = DEFAULT_DELAY;
                 interval = DEFAULT_INTERVAL;
                 maxAttempts = DEFAULT_MAX_ATTEMPTS;
+                afkDetection = DEFAULT_AFK_DETECTION;
+                afkDelay = DEFAULT_AFK_DELAY;
                 AutoRelogClient.LOGGER.info("No AutoRelog config found, loading default");
             } else {
                 delay = root.node("delay").empty() ? DEFAULT_DELAY : root.node("delay").getInt();
                 interval = root.node("interval").empty() ? DEFAULT_INTERVAL : root.node("interval").getInt();
                 maxAttempts = root.node("maxAttempts").empty() ? DEFAULT_MAX_ATTEMPTS : root.node("maxAttempts").getInt();
+                afkDetection = root.node("afkDetection").empty() ? DEFAULT_AFK_DETECTION : root.node("afkDetection").getBoolean();
+                afkDelay = root.node("afkDelay").empty() ? DEFAULT_AFK_DELAY : root.node("afkDelay").getInt();
                 AutoRelogClient.LOGGER.info("Loaded AutoRelog config");
             }
             save();
@@ -82,6 +110,8 @@ public class Config {
             root.node("delay").set(Integer.class, delay).comment("Delay must be higher than 1");
             root.node("interval").set(Integer.class, interval).comment("Interval must be higher than 1");
             root.node("maxAttempts").set(Integer.class, maxAttempts).comment("Max attempts must be higher than 0. Set to 0 for infinite attempts");
+            root.node("afkDetection").set(Boolean.class, afkDetection);
+            root.node("afkDelay").set(Integer.class, afkDelay).comment("Delay must be higher than 0. AFK-Detection will be force-disabled otherwise.");
             loader.save(root);
         } catch (final ConfigurateException e) {
             AutoRelogClient.LOGGER.info("Unable to save your AutoRelog configuration! Sorry! " + e.getMessage());

--- a/src/main/java/com/scubakay/autorelog/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/scubakay/autorelog/mixin/ClientPlayerEntityMixin.java
@@ -1,0 +1,56 @@
+package com.scubakay.autorelog.mixin;
+
+import com.scubakay.autorelog.AutoRelogClient;
+import com.scubakay.autorelog.util.Reconnect;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.input.Input;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.recipebook.ClientRecipeBook;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.MovementType;
+import net.minecraft.stat.StatHandler;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+import org.checkerframework.checker.units.qual.A;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPlayerEntity.class)
+public abstract class ClientPlayerEntityMixin {
+    @Shadow
+    public Input input;
+
+    @Unique
+    private long lastInput = 0;
+
+    //initializing with Reconnect::isActive required for afk detection to work properly after a relog
+    @Unique
+    private boolean isAfk = Reconnect.getInstance().isActive() && AutoRelogClient.CONFIG.isAfkDetection();
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void detectInput(CallbackInfo ci) {
+        if(lastInput == 0) lastInput = System.currentTimeMillis();
+        if (!AutoRelogClient.CONFIG.isAfkDetection()) return;
+        checkIsAfk(input.getMovementInput());
+    }
+
+    @Unique
+    private void checkIsAfk(Vec2f movementVec) {
+        if (movementVec.equals(Vec2f.ZERO)) {
+            if (isAfk) return;
+            if (System.currentTimeMillis() - lastInput < AutoRelogClient.CONFIG.getAfkDelay() * 1000L) return;
+            isAfk = true;
+            Reconnect.getInstance().activate();
+            return;
+        }
+        lastInput = System.currentTimeMillis();
+        if (!isAfk) return;
+        isAfk = false;
+        Reconnect.getInstance().deactivate();
+    }
+}

--- a/src/main/java/com/scubakay/autorelog/util/Reconnect.java
+++ b/src/main/java/com/scubakay/autorelog/util/Reconnect.java
@@ -37,6 +37,10 @@ public class Reconnect {
         timer = new Timer();
     }
 
+    public boolean isActive() {
+        return active;
+    }
+
     public void activate() {
         if (!active) {
             AutoRelogClient.LOGGER.info("AutoRelog activated");

--- a/src/main/resources/assets/autorelog/lang/en_us.json
+++ b/src/main/resources/assets/autorelog/lang/en_us.json
@@ -7,5 +7,8 @@
   "commands.autorelog_max_attempts_changed": "Changed AutoRelog maxAttempts to %d",
   "commands.config_error_max_attempts": "Max attempts must be a positive number. Enter 0 for infinite attempts.",
   "commands.config_error_delay": "Delay must be above zero",
-  "commands.config_error_interval": "Interval must be above zero"
+  "commands.config_error_interval": "Interval must be above zero",
+  "commands.mode.manual": "AutoRelog manual mode activated",
+  "commands.mode.afkDetection": "AutoRelog AFK-Detection activated",
+  "commands.afkDetection.delayChanged": "Changed AFK-Detection delay to %d seconds"
 }

--- a/src/main/resources/autorelog.mixins.json
+++ b/src/main/resources/autorelog.mixins.json
@@ -6,9 +6,10 @@
   "mixins": [
   ],
   "client": [
+    "DisconnectedScreenMixin",
     "GameMenuScreenMixin",
-    "MultiplayerScreenMixin",
-    "DisconnectedScreenMixin"
+    "ClientPlayerEntityMixin",
+    "MultiplayerScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This adds automatic AFK-Detection so you don't have to manually enable the autorelogger every time you go afk.

This mode is disabled by default and can be turned on by using `/autorelog config mode automatic`.

The duration for which you have to be still for it to detect you as being afk can be configured by using /autorelog config afkDelay <delay>` (in seconds)